### PR TITLE
Loudness normalization

### DIFF
--- a/helpers/helper_bot.py
+++ b/helpers/helper_bot.py
@@ -47,7 +47,7 @@ class HelperBot(commands.Bot):
         """ Play the next sound in queue. If none, disconnect """
         if len(self.soundQueue) != 0:
             sound = self.soundQueue[0]
-            self.currentVoiceClient.play(discord.FFmpegPCMAudio(sound.location), after=self.after_sound_clip)
+            self.currentVoiceClient.play(discord.FFmpegPCMAudio(sound.location, options="-filter:a loudnorm"), after=self.after_sound_clip)
         else:
             await self.disconnect()
 


### PR DESCRIPTION
The bot should normalize the sounds played to discord's 100% now, which means bots should be kept at 100% for normal loudness.